### PR TITLE
Fix notification sound

### DIFF
--- a/cordova_push.mli
+++ b/cordova_push.mli
@@ -357,7 +357,7 @@ module Channel_properties : sig
     ?id:string ->
     ?description:string->
     ?importance:int->
-    ?sound:(bool [@js.default true])->
+    ?sound:(string [@js.default "default"])->
     ?vibration:(bool [@js.default true]) ->
     ?visibility:(int [@js.default 1]) ->
     unit ->


### PR DESCRIPTION
See
https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/API.md#channel-properties

In channel creation, sound property id a string (filename), not a bool.
Current version results in looking a file called "raw/true.mp3"
